### PR TITLE
Fix for building projects with Position3Drawer.cs

### DIFF
--- a/Runtime/Math/Editor/Position3Drawer.cs
+++ b/Runtime/Math/Editor/Position3Drawer.cs
@@ -1,4 +1,6 @@
-﻿using UnityEditor;
+#if UNITY_EDITOR
+
+using UnityEditor;
 using UnityEngine;
 
 namespace MUtility.Editor
@@ -18,11 +20,11 @@ public class Position3Drawer : PropertyDrawer
         contentRect.Split(rate: 0.25f, out Rect typeRect, out Rect valueRect);
         int indent = EditorGUI.indentLevel;
         EditorGUI.indentLevel = 0;
-        
+
         EditorGUI.PropertyField(typeRect, sourceTypeProperty, GUIContent.none);
 
         Position3.SourceType t = (Position3.SourceType) sourceTypeProperty.enumValueIndex;
-        
+
         if(t == Position3.SourceType.Transform)
             EditorGUI.PropertyField(valueRect, transformSourceProperty, GUIContent.none);
         else if (t == Position3.SourceType.Vector)
@@ -31,3 +33,4 @@ public class Position3Drawer : PropertyDrawer
     }
 }
 }
+#endif


### PR DESCRIPTION
Position3Drawer had not the #if UNITY_EDITOR preprocessor directive, which does not allow to build any project containing this package. Once this preprocessor directive is included, Unity projects are able to build.